### PR TITLE
Improve support for 4:3 aspect ratio cameras and higher resolution cameras

### DIFF
--- a/src/lib/CameraPhoto/MediaServices/MediaServices.js
+++ b/src/lib/CameraPhoto/MediaServices/MediaServices.js
@@ -135,6 +135,7 @@ export class MediaServices {
       { width: { min: 2560 } }, // 16:9
       { width: { min: 2880 } }, // 3K UHD (16:9), 4K UHD (4:3)
       { width: { min: 3072 } }, // 3K (16:9), 4K (4:3)
+      { width: { min: 3264 } }, // 8MP (4:3)
       { width: { min: 3840 } }, // 4K UHD (16:9), 5K (4:3)
       { width: { min: 4096 } }, // 4K (16:9)
       { width: { min: 4608 } }, // 6K (4:3)

--- a/src/lib/CameraPhoto/MediaServices/MediaServices.js
+++ b/src/lib/CameraPhoto/MediaServices/MediaServices.js
@@ -122,12 +122,27 @@ export class MediaServices {
       { width: { min: 640 } },
       { width: { min: 800 } },
       { width: { min: 900 } },
+      { width: { min: 960 } }, // 720p (4:3)
       { width: { min: 1024 } },
       { width: { min: 1080 } },
-      { width: { min: 1280 } },
-      { width: { min: 1920 } },
-      { width: { min: 2560 } },
-      { width: { min: 3840 } }
+      { width: { min: 1280 } }, // 720p (16:9)
+      { width: { min: 1440 } }, // 1080p (4:3)
+      { width: { min: 1536 } }, // 2K (4:3)
+      { width: { min: 1920 } }, // 1080p (16:9)
+      { width: { min: 2048 } }, // 2K (16:9)
+      { width: { min: 2160 } }, // 3K UHD (4:3)
+      { width: { min: 2304 } }, // 3K (4:3)
+      { width: { min: 2560 } }, // 16:9
+      { width: { min: 2880 } }, // 3K UHD (16:9), 4K UHD (4:3)
+      { width: { min: 3072 } }, // 3K (16:9), 4K (4:3)
+      { width: { min: 3840 } }, // 4K UHD (16:9), 5K (4:3)
+      { width: { min: 4096 } }, // 4K (16:9)
+      { width: { min: 4608 } }, // 6K (4:3)
+      { width: { min: 5120 } }, // 5K (16:9)
+      { width: { min: 5760 } }, // 8K UHD (4:3)
+      { width: { min: 6144 } }, // 8k (4:3), 6K (16:9)
+      { width: { min: 7680 } }, // 8K UHD (16:9)
+      { width: { min: 8192 } } // 8K (16:9)
     ];
 
     let stdConstraints = MediaServices.getIdealConstraints(idealCameraDevice, {});


### PR DESCRIPTION
**Problem:** Some devices have 4:3 aspect ratio cameras. The current constraints don't allow those cameras to capture near their full quality because the provided constraints are too far above or below the full width of those cameras.

The issue we encountered specifically was that an 8MP webcam with a 4:3 aspect ratio (3264 x 2448) was falling all the way back to  2560 which was a very large dropoff in quality.

**Proposed Solution:** Add some additional constraints to better target more devices.

**Alternatives:** An alternative would be to allow passing constraints in so that we as consumers could make the list as comprehensive as we want, but that would require more work both here and in `react-html5-camera-photo` which uses this library as a dependency.